### PR TITLE
Use variables to fit in with themes

### DIFF
--- a/JournalCalendar/Library/JournalCalendar/JournalCalendar.md
+++ b/JournalCalendar/Library/JournalCalendar/JournalCalendar.md
@@ -120,6 +120,10 @@ end
   text-align: left;
 }
 
+.calendartable td.mark {
+  background-color: var(--ui-accent-color);
+}
+
 .calendartable a {
   text-decoration-line: none;
   color: var(--root-color);

--- a/JournalCalendar/Library/JournalCalendar/JournalCalendar.md
+++ b/JournalCalendar/Library/JournalCalendar/JournalCalendar.md
@@ -98,37 +98,35 @@ end
 
 ```space-style
 .calendartable {
-  /* color: blue; */
   border-collapse: collapse; 
   width: 400px;
 }
 
+.calendartable table {
+  border-color: var(--panel-border-color);
+}
+
 .calendartable th {
   width: 10%;
-  border: 1px solid black;
   padding: 3px; 
   text-align: left;  
-  background-color: lightgray;
+  background-color: var(--panel-background-color);
 }
+
 
 .calendartable td {
   width: 10%;
-  border: 1px solid gray; 
   padding: 3px; 
-  text-align: left;  
-}
-
-.calendartable td.mark {
-  background-color: orange;
+  text-align: left;
 }
 
 .calendartable a {
- text-decoration-line: none;
- color: black;
+  text-decoration-line: none;
+  color: var(--root-color);
 }
 
 .calendartable a.mark {
- text-decoration-line: none;
- color: blue;
+  text-decoration-line: none;
+  color: var(--ui-accent-text-color);
 }
 ```


### PR DESCRIPTION
By using the CSS variables defined by SilverBullet, we can more easily make the calendar fit in with the rest of the space.

Example using my theme inspired by Logseq:

![image](https://github.com/user-attachments/assets/b322360b-a020-4c0c-90ca-61b9c991c09f)
